### PR TITLE
Separate throw and emit

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -2,7 +2,7 @@ import { test } from "uvu";
 import { snoop } from "snoop";
 import * as assert from "uvu/assert";
 
-import { createError, type IConwayError } from "./index";
+import { createError, isConwayError, type IConwayError } from "./index";
 
 test("without error types will throw always UnknownError", () => {
   const createErrorContext = createError();
@@ -125,7 +125,7 @@ test("createMessagePostfix add message if originalError provided", () => {
   }
 });
 
-test("createContext provide context from createError to feature and available in emitAndThrow", () => {
+test("createContext provide context from createError to feature and available in emitting", () => {
   const mockedEmit = snoop((err, extendedParams) => {});
 
   const createErrorContext = createError([{ errorType: "ErrorType1" }, { errorType: "ErrorType2" }] as const, {
@@ -202,6 +202,24 @@ test("createContext provide context from createError to feature and available in
       ctxE: 5,
     },
   );
+});
+
+test("isConwayError type guard works correctly", () => {
+  assert.equal(isConwayError(null), false);
+  assert.equal(isConwayError("just string"), false);
+  assert.equal(isConwayError(0), false);
+
+  const nativeError = new Error("Native JS error");
+  assert.equal(isConwayError(nativeError), false);
+
+  const createErrorContext = createError();
+  const errorContext = createErrorContext("Context");
+  const feature = errorContext.feature("Feature");
+  try {
+    feature.throw("ErrorName", "ErrorMessage");
+  } catch (err: any) {
+    assert.equal(isConwayError(err), true);
+  }
 });
 
 test.run();

--- a/index.test.ts
+++ b/index.test.ts
@@ -2,7 +2,7 @@ import { test } from "uvu";
 import { snoop } from "snoop";
 import * as assert from "uvu/assert";
 
-import { createError } from "./index";
+import { createError, type IConwayError } from "./index";
 
 test("without error types will throw always UnknownError", () => {
   const createErrorContext = createError();
@@ -66,32 +66,35 @@ test("nested context write correct message", () => {
   }
 });
 
-test("custom throw function should override default throw", () => {
-  const mockedThrow = snoop((err, context) => {});
+test("custom emit function should override default emit", () => {
+  const mockedEmit = snoop((err, context) => {});
 
   const createErrorContext = createError([{ errorType: "ErrorType1" }, { errorType: "ErrorType2" }] as const, {
-    throwFn: (err, context) => {
-      mockedThrow.fn(err.message, context);
+    emitFn: (err, context) => {
+      mockedEmit.fn(err.message, context);
     },
   });
 
   const errorContext = createErrorContext("Context");
   const feature = errorContext.feature("Feature");
 
-  assert.not.throws(() => {
+  try {
     feature.throw("ErrorType1", "ErrorMessage");
-  });
+  } catch (error) {
+    feature.emitThrownError(error as IConwayError);
+    assert.ok(mockedEmit.calledOnce);
+  }
 
   assert.equal(
     // @ts-ignore
-    mockedThrow.calls[0].arguments[0],
-    "Context/Feature: ErrorMessage"
+    mockedEmit.calls[0].arguments[0],
+    "Context/Feature: ErrorMessage",
   );
 
   assert.equal(
     // @ts-ignore
-    mockedThrow.calls[0].arguments[1],
-    {}
+    mockedEmit.calls[0].arguments[1],
+    {},
   );
 });
 
@@ -108,29 +111,29 @@ test("createMessagePostfix add message if originalError provided", () => {
   const originalError = new Error("OriginalError");
 
   try {
-    feature.throw("ErrorType1", "ErrorMessage", { originalError });
+    feature.throw("ErrorType1", "ErrorMessage", originalError);
   } catch (err: any) {
     assert.is(err.name, "ErrorType1");
     assert.is(err.message, "Context/Subcontext1/Feature: ErrorMessage >>> OriginalError");
   }
 
   try {
-    feature.throw("ErrorType2", "ErrorMessage", { originalError });
+    feature.throw("ErrorType2", "ErrorMessage", originalError);
   } catch (err: any) {
     assert.is(err.name, "ErrorType2");
     assert.is(err.message, "Context/Subcontext1/Feature: ErrorMessage some additional info");
   }
 });
 
-test("createContext provide context from createError to feature and available in throwFn", () => {
-  const mockedThrow = snoop((err, extendedParams) => {});
+test("createContext provide context from createError to feature and available in emitAndThrow", () => {
+  const mockedEmit = snoop((err, extendedParams) => {});
 
   const createErrorContext = createError([{ errorType: "ErrorType1" }, { errorType: "ErrorType2" }] as const, {
     extendedParams: {
       ctxA: 1,
     },
-    throwFn: (err, extendedParams) => {
-      mockedThrow.fn(err, extendedParams);
+    emitFn: (err, extendedParams) => {
+      mockedEmit.fn(err, extendedParams);
     },
   });
 
@@ -146,18 +149,21 @@ test("createContext provide context from createError to feature and available in
     ctxD: 4,
   });
 
-  feature1.throw("ErrorType1", "ErrorMessage");
-
-  assert.equal(
-    // @ts-ignore
-    mockedThrow.calls[0].arguments[1],
-    {
-      ctxA: 1,
-      ctxB: 2,
-      ctxC: 3,
-      ctxD: 4,
-    }
-  );
+  try {
+    feature1.throw("ErrorType1", "ErrorMessage");
+  } catch (error) {
+    feature1.emitThrownError(error as IConwayError);
+    assert.equal(
+      // @ts-ignore
+      mockedEmit.calls[0].arguments[1],
+      {
+        ctxA: 1,
+        ctxB: 2,
+        ctxC: 3,
+        ctxD: 4,
+      },
+    );
+  }
 
   // rewrite context
 
@@ -171,31 +177,30 @@ test("createContext provide context from createError to feature and available in
     ctxD: 4,
   });
 
-  feature2.throw("ErrorType1", "ErrorMessage");
+  feature2.emit("ErrorType1", "ErrorMessage");
 
   assert.equal(
     // @ts-ignore
-    mockedThrow.calls[1].arguments[1],
+    mockedEmit.calls[1].arguments[1],
     {
       ctxA: 100,
       ctxB: 1000,
       ctxC: 3,
       ctxD: 4,
-    }
+    },
   );
 
-  feature2.throw("ErrorType1", "ErrorMessage", { extendedParams: { ctxE: 5 } });
-
+  feature2.emit("ErrorType1", "ErrorMessage", { extendedParams: { ctxE: 5 } });
   assert.equal(
     // @ts-ignore
-    mockedThrow.calls[2].arguments[1],
+    mockedEmit.calls[2].arguments[1],
     {
       ctxA: 100,
       ctxB: 1000,
       ctxC: 3,
       ctxD: 4,
       ctxE: 5,
-    }
+    },
   );
 });
 

--- a/index.ts
+++ b/index.ts
@@ -8,9 +8,9 @@ export interface IConwayError extends Error {
 }
 
 class ConwayError extends Error implements IConwayError {
-  rootContext: string;
-  contextsChunk: string;
-  originalError?: OriginalError;
+  readonly rootContext: string;
+  readonly contextsChunk: string;
+  readonly originalError?: OriginalError;
 
   constructor(
     name: string,
@@ -22,8 +22,8 @@ class ConwayError extends Error implements IConwayError {
     super(message);
     this.name = name;
     this.rootContext = rootContext;
-    this.originalError = originalError;
     this.contextsChunk = contextsChunk;
+    this.originalError = originalError;
   }
 }
 /**

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Root interface for any specific error type.
+ */
 export interface IConwayError extends Error {
   rootContext: string;
   contextsChunk: string;
@@ -22,6 +25,14 @@ class ConwayError extends Error implements IConwayError {
     this.originalError = originalError;
     this.contextsChunk = contextsChunk;
   }
+}
+/**
+ * Type guard which helps to understand if error is Conway error.
+ * @param error
+ * @return {boolean}
+ */
+export function isConwayError(error: unknown): error is IConwayError {
+  return typeof error === "object" && error instanceof ConwayError;
 }
 
 function createErrorClass(name: string, rootContext: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conway-errors",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conway-errors",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conway-errors",
   "source": "index.ts",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "private": false,
   "description": "Create errors with Conway's law",
   "exports": {


### PR DESCRIPTION
1. Implemented separate logic of 'throwing' and 'emitting'. Now API of 'featureError'  object allows to throw error, emit previously thrown error and emit without throwing.

2. Renamed BaseError to ConwayError. I think it is pretty ).

3. Added `original error` and `contexts chunk` as fields of ConwayError.

4. Added type guard to check if error is Conway. 
It is helpful when in `catch` block we try to understand if we throw it or JS by itself.

5. Supported new changes in tests.

6. Increase major version, because it is breaking changes.