### PR TITLE
feat: do not implement throw function in library, allow client to throw error instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ const oauthError = errorAuthTeamContext.feature("OauthError");
 const paymentError = errorPaymentTeamContext.feature("PaymentError");
 
 // (4) Example of throwing errors
-oauthError.throw("FrontendLogickError", "User not found");
-paymentError.throw("BackendLogickError", "Payment already processed");
+throw oauthError("FrontendLogickError", "User not found");
+throw paymentError("BackendLogickError", "Payment already processed");
 
 // (5) Example of emitting thrown errors
 try {
-  oauthError.throw("FrontendLogickError", "User not found");
+  throw oauthError("FrontendLogickError", "User not found");
 }
 catch(error) {
-  oauthError.emitThrownError(error);
+  oauthError.emitCreatedError(error);
 }
 
 // (6) You also can emit error without throwing
@@ -64,8 +64,8 @@ const facebookError = socialAuthErrorContext.feature("FacebookAuth");
 const smsSendError = phoneAuthErrorContext.feature("SmsSender");
 
 // (4) Example of throwing errors
-facebookError.throw("FrontendLogickError", "Account inactive");
-smsSendError.throw("BackendLogickError", "Limit exceed");
+throw facebookError("FrontendLogickError", "Account inactive");
+throw smsSendError("BackendLogickError", "Limit exceed");
 ```
 
 ### Overriding the Error Emitting Function
@@ -98,12 +98,12 @@ const createErrorContext = createError([
 ] as const);
 
 const context = createErrorContext("Context");
-const feature = subcontext.feature("Feature");
+const featureError = subcontext.feature("Feature");
 
 try {
   uploadAvatar();
 } catch (err) {
-  feature.emit("FrontendLogickError", "Failed upload avatar", err);
+  featureError.emit("FrontendLogickError", "Failed upload avatar", err);
   // The following error will be emitted:
   // FrontendLogickError("Context/Feature: Failed upload avatar >>> Server upload avatar failed")
 }
@@ -142,9 +142,9 @@ const paymentErrorContext = createErrorContext("Payment", {
   subdomain: "Payment",
 });
 
-const cardPaymentError = subcontext.feature("Cardpayment", {
+const cardPaymentError = subcontext.feature("CardPayment", {
   location: "USA",
 });
 
-cardPaymentError.throw("BackendLogickError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
+throw cardPaymentError("BackendLogickError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const createErrorContext = createError([
 ### Extending Base Error Messages
 
 ```ts
-import { createError } from "conway-errors"; 
+import { createError } from "conway-errors";
 
 const createErrorContext = createError([
   { errorType: "FrontendLogickError", createMessagePostfix: (originalError) => " >>> " + originalError?.message },

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ try {
   throw oauthError("FrontendLogicError", "User not found");
 }
 catch(error) {
-  oauthError.emitCreatedError(error);
+  (error as IConwayError).emit(error);
 }
 
 // (6) You also can emit error without throwing
-oauthError.emit("FrontendLogicError", "User not found");
+oauthError("FrontendLogicError", "User not found").emit();
 ```
 
 ### Nested Contexts
@@ -93,7 +93,7 @@ const createErrorContext = createError([
 import { createError } from "conway-errors";
 
 const createErrorContext = createError([
-  { errorType: "FrontendLogicError", createMessagePostfix: (originalError) => " >>> " + originalError?.message },
+  { errorType: "FrontendLogicError", createMessagePostfix: (originalError) => " >>> " + (originalError as Error).message },
   { errorType: "BackendLogicError" },
 ] as const);
 
@@ -103,7 +103,7 @@ const featureError = subcontext.feature("Feature");
 try {
   uploadAvatar();
 } catch (err) {
-  featureError.emit("FrontendLogicError", "Failed upload avatar", err);
+  featureError("FrontendLogicError", "Failed upload avatar", err).emit();
   // The following error will be emitted:
   // FrontendLogicError("Context/Feature: Failed upload avatar >>> Server upload avatar failed")
 }
@@ -146,5 +146,5 @@ const cardPaymentError = subcontext.feature("CardPayment", {
   location: "USA",
 });
 
-throw cardPaymentError("BackendLogicError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
+throw cardPaymentError("BackendLogicError", "Payment failed").emit({ extendedParams: { logLevel: "fatal" } });
 ```

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ import { createError } from "conway-errors";
 
 // (1) Create the root context, where the base error types are defined
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError" },
-  { errorType: "BackendLogickError" },
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" },
 ] as const);
 
 // (2) Create any number of contexts, for example, divided by team or context
@@ -26,19 +26,19 @@ const oauthError = errorAuthTeamContext.feature("OauthError");
 const paymentError = errorPaymentTeamContext.feature("PaymentError");
 
 // (4) Example of throwing errors
-throw oauthError("FrontendLogickError", "User not found");
-throw paymentError("BackendLogickError", "Payment already processed");
+throw oauthError("FrontendLogicError", "User not found");
+throw paymentError("BackendLogicError", "Payment already processed");
 
 // (5) Example of emitting thrown errors
 try {
-  throw oauthError("FrontendLogickError", "User not found");
+  throw oauthError("FrontendLogicError", "User not found");
 }
 catch(error) {
   oauthError.emitCreatedError(error);
 }
 
 // (6) You also can emit error without throwing
-oauthError.emit("FrontendLogickError", "User not found");
+oauthError.emit("FrontendLogicError", "User not found");
 ```
 
 ### Nested Contexts
@@ -48,8 +48,8 @@ import { createError } from "conway-errors";
 
 // (1) Create the root context, where the base error types are defined
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError" },
-  { errorType: "BackendLogickError" },
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" },
 ] as const);
 
 // (2) Create any number of contexts, for example, divided by team or context
@@ -64,8 +64,8 @@ const facebookError = socialAuthErrorContext.feature("FacebookAuth");
 const smsSendError = phoneAuthErrorContext.feature("SmsSender");
 
 // (4) Example of throwing errors
-throw facebookError("FrontendLogickError", "Account inactive");
-throw smsSendError("BackendLogickError", "Limit exceed");
+throw facebookError("FrontendLogicError", "Account inactive");
+throw smsSendError("BackendLogicError", "Limit exceed");
 ```
 
 ### Overriding the Error Emitting Function
@@ -77,8 +77,8 @@ import { createError } from "conway-errors";
 import * as Sentry from "@sentry/nextjs";
 
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError" },
-  { errorType: "BackendLogickError" }
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" }
 ] as const, {
   // use sentry to log errors instead of default behavior with console.error()
   emitFn: (err) => {
@@ -93,8 +93,8 @@ const createErrorContext = createError([
 import { createError } from "conway-errors";
 
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError", createMessagePostfix: (originalError) => " >>> " + originalError?.message },
-  { errorType: "BackendLogickError" },
+  { errorType: "FrontendLogicError", createMessagePostfix: (originalError) => " >>> " + originalError?.message },
+  { errorType: "BackendLogicError" },
 ] as const);
 
 const context = createErrorContext("Context");
@@ -103,9 +103,9 @@ const featureError = subcontext.feature("Feature");
 try {
   uploadAvatar();
 } catch (err) {
-  featureError.emit("FrontendLogickError", "Failed upload avatar", err);
+  featureError.emit("FrontendLogicError", "Failed upload avatar", err);
   // The following error will be emitted:
-  // FrontendLogickError("Context/Feature: Failed upload avatar >>> Server upload avatar failed")
+  // FrontendLogicError("Context/Feature: Failed upload avatar >>> Server upload avatar failed")
 }
 ```
 
@@ -115,7 +115,7 @@ try {
 import { createError } from "conway-errors"; 
 import * as Sentry from "@sentry/nextjs";
 
-const createErrorContext = createError(["FrontendLogickError", "BackendLogickError"], {
+const createErrorContext = createError(["FrontendLogicError", "BackendLogicError"], {
   extendedParams: {
     isSSR: typeof window === "undefined",
     projectName: "My cool frontend"
@@ -146,5 +146,5 @@ const cardPaymentError = subcontext.feature("CardPayment", {
   location: "USA",
 });
 
-throw cardPaymentError("BackendLogickError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
+throw cardPaymentError("BackendLogicError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
 ```

--- a/README_RU.md
+++ b/README_RU.md
@@ -34,11 +34,11 @@ try {
   throw oauthError("FrontendLogicError", "User not found");
 }
 catch(error) {
-  oauthError.emitCreatedError(error);
+  (error as IConwayError).emit(error);
 }
 
 // (6) Пример эмиттинга ошибок без вызова throw 
-oauthError.emit("FrontendLogicError", "User not found");
+oauthError("FrontendLogicError", "User not found").emit();
 ```
 
 ### Вложенные контексты
@@ -149,5 +149,5 @@ const cardPaymentError = subcontext.feature("CardPayment", {
   location: "USA",
 });
 
-throw cardPaymentError("BackendLogicError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
+throw cardPaymentError("BackendLogicError", "Payment failed").emit({ extendedParams: { logLevel: "fatal" } });
 ```

--- a/README_RU.md
+++ b/README_RU.md
@@ -13,8 +13,8 @@ import { createError } from "conway-errors";
 
 // (1) создаем корневой контекст, где определяются базовые типы ошибок
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError" },
-  { errorType: "BackendLogickError" },
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" },
 ] as const);
 
 // (2) создаем любое количество контекстов, например разделяем по команде или контексту
@@ -26,8 +26,8 @@ const oauthError = errorAuthTeamContext.feature("OauthError");
 const paymentError = errorPaymentTeamContext.feature("PaymentError");
 
 // (4) пример выброса ошибок
-oauthError.throw("FrontendLogickError", "User not found");
-paymentError.throw("BackendLogickError", "Payment already processed");
+oauthError.throw("FrontendLogicError", "User not found");
+paymentError.throw("BackendLogicError", "Payment already processed");
 ```
 
 ### Вложенные контексты
@@ -37,8 +37,8 @@ import { createError } from "conway-errors";
 
 // (1) создаем корневой контекст, где определяются базовые типы ошибок
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError" },
-  { errorType: "BackendLogickError" },
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" },
 ] as const);
 
 // (2) создаем любое количество контекстов, например разделяем по команде или контексту
@@ -53,8 +53,8 @@ const facebookError = socialAuthErrorContext.feature("FacebookAuth");
 const smsSendError = phoneAuthErrorContext.feature("SmsSender");
 
 // (4) пример выброса ошибок
-facebookError.throw("FrontendLogickError", "Account inactive");
-smsSendError.throw("BackendLogickError", "Limit exceed");
+facebookError.throw("FrontendLogicError", "Account inactive");
+smsSendError.throw("BackendLogicError", "Limit exceed");
 ```
 
 ### Переопределение функции выброса ошибки
@@ -66,8 +66,8 @@ import { createError } from "conway-errors";
 import * as Sentry from "@sentry/nextjs";
 
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError" },
-  { errorType: "BackendLogickError" }
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" }
 ] as const, {
   // переопределяем поведение выброса ошибки
   throwFn: (err) => {
@@ -84,8 +84,8 @@ const createErrorContext = createError([
 import { createError } from "conway-errors"; 
 
 const createErrorContext = createError([
-  { errorType: "FrontendLogickError", createMessagePostfix: (originalError) => " >>> " + originalError?.message },
-  { errorType: "BackendLogickError" },
+  { errorType: "FrontendLogicError", createMessagePostfix: (originalError) => " >>> " + originalError?.message },
+  { errorType: "BackendLogicError" },
 ] as const);
 
 const context = createErrorContext("Context");
@@ -94,9 +94,9 @@ const feature = subcontext.feature("Feature");
 try {
   uploadAvatar();
 } catch (err) {
-  feature.throw("FrontendLogickError", "Failed upload avatar", err);
+  feature.throw("FrontendLogicError", "Failed upload avatar", err);
   // будет выброшена ошибка:
-  // FrontendLogickError("Context/Feature: Failed upload avatar >>> Server upload avatar failed")
+  // FrontendLogicError("Context/Feature: Failed upload avatar >>> Server upload avatar failed")
 }
 ```
 
@@ -106,7 +106,7 @@ try {
 import { createError } from "conway-errors"; 
 import * as Sentry from "@sentry/nextjs";
 
-const createErrorContext = createError(["FrontendLogickError", "BackendLogickError"], {
+const createErrorContext = createError(["FrontendLogicError", "BackendLogicError"], {
   extendedParams: {
     isSSR: typeof window === "undefined",
     projectName: "My cool frontend"
@@ -138,5 +138,5 @@ const cardPaymentError = subcontext.feature("Cardpayment", {
   location: "USA",
 });
 
-cardPaymentError.throw("BackendLogickError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
+cardPaymentError.throw("BackendLogicError", "Payment failed", { extendedParams: { logLevel: "fatal" } });
 ```

--- a/index.test.ts
+++ b/index.test.ts
@@ -78,7 +78,7 @@ test("custom emit function should override default emit", () => {
   const errorContext = createErrorContext("Context");
   const featureError = errorContext.feature("Feature");
 
-  featureError.emit("ErrorType1", "ErrorMessage");
+  featureError("ErrorType1", "ErrorMessage").emit();
 
   assert.ok(mockedEmit.calledOnce);
 
@@ -97,7 +97,7 @@ test("custom emit function should override default emit", () => {
 
 test("createMessagePostfix add message if originalError provided", () => {
   const createErrorContext = createError([
-    { errorType: "ErrorType1", createMessagePostfix: (originalError) => " >>> " + originalError?.message },
+    { errorType: "ErrorType1", createMessagePostfix: (originalError) => " >>> " + (originalError as Error).message },
     { errorType: "ErrorType2", createMessagePostfix: () => " some additional info" },
   ] as const);
 
@@ -146,21 +146,17 @@ test("createContext provide context from createError to feature and available in
     ctxD: 4,
   });
 
-  try {
-    throw feature1Error("ErrorType1", "ErrorMessage");
-  } catch (error) {
-    feature1Error.emitCreated(error as IConwayError);
-    assert.equal(
-      // @ts-ignore
-      mockedEmit.calls[0].arguments[1],
-      {
-        ctxA: 1,
-        ctxB: 2,
-        ctxC: 3,
-        ctxD: 4,
-      },
-    );
-  }
+  feature1Error("ErrorType1", "ErrorMessage").emit();
+  assert.equal(
+    // @ts-ignore
+    mockedEmit.calls[0].arguments[1],
+    {
+      ctxA: 1,
+      ctxB: 2,
+      ctxC: 3,
+      ctxD: 4,
+    },
+  );
 
   // rewrite context
 
@@ -174,7 +170,7 @@ test("createContext provide context from createError to feature and available in
     ctxD: 4,
   });
 
-  feature2Error.emit("ErrorType1", "ErrorMessage");
+  feature2Error("ErrorType1", "ErrorMessage").emit();
 
   assert.equal(
     // @ts-ignore
@@ -187,7 +183,7 @@ test("createContext provide context from createError to feature and available in
     },
   );
 
-  feature2Error.emit("ErrorType1", "ErrorMessage", { extendedParams: { ctxE: 5 } });
+  feature2Error("ErrorType1", "ErrorMessage").emit({ ctxE: 5 });
   assert.equal(
     // @ts-ignore
     mockedEmit.calls[2].arguments[1],

--- a/index.test.ts
+++ b/index.test.ts
@@ -70,7 +70,7 @@ test("custom emit function should override default emit", () => {
   const mockedEmit = snoop((err, context) => {});
 
   const createErrorContext = createError([{ errorType: "ErrorType1" }, { errorType: "ErrorType2" }] as const, {
-    emitFn: (err, context) => {
+    handleEmit: (err, context) => {
       mockedEmit.fn(err.message, context);
     },
   });
@@ -129,7 +129,7 @@ test("createContext provide context from createError to feature and available in
     extendedParams: {
       ctxA: 1,
     },
-    emitFn: (err, extendedParams) => {
+    handleEmit: (err, extendedParams) => {
       mockedEmit.fn(err, extendedParams);
     },
   });

--- a/index.ts
+++ b/index.ts
@@ -53,7 +53,7 @@ function defaultEmitFn(err: IConwayError) {
 
 type ExtendedParams = Record<string, unknown>;
 
-type OriginalError = Error | Record<string, unknown>;
+type OriginalError = Error | Record<string, unknown> | unknown;
 
 interface CreateErrorOptions {
   emitFn?: (err: IConwayError, extendedParams?: ExtendedParams) => void;

--- a/index.ts
+++ b/index.ts
@@ -118,7 +118,21 @@ type ObjectWithEmit<ErrorType> = {
 };
 
 type ErrorSubcontext<ErrorType extends string> = {
+  /**
+   * Create a child context within the current context.
+   *
+   * @param {string} childContextName - The name of the child context.
+   * @param {ExtendedParams} extendedParams - Additional extended parameters for the child context.
+   * @return {Function} Function to create an error context with the specified child context name and extended params.
+   */
   subcontext: (subcontextName: string, extendedParams?: ExtendedParams) => ErrorSubcontext<ErrorType>;
+  /**
+   * Creates a child feature within the current context.
+   *
+   * @param {string} childFeatureName - The name of the child feature.
+   * @param {ExtendedParams} [extendedParams={}] - Additional extended parameters for the child feature.
+   * @return {Function} The created error feature.
+   */
   feature: FeatureFn<ErrorType>;
 };
 
@@ -160,21 +174,7 @@ export function createError<ErrorTypes extends ErrorTypeConfig>(errorTypes?: Err
       contextExtendedParams: ExtendedParams = outerExtendedParams,
     ): ErrorSubcontext<ErrorTypes[number]["errorType"]> {
       return {
-        /**
-         * Create a child context within the current context.
-         *
-         * @param {string} childContextName - The name of the child context.
-         * @param {ExtendedParams} extendedParams - Additional extended parameters for the child context.
-         * @return {Function} Function to create an error context with the specified child context name and extended params.
-         */
         subcontext: _createSubcontext(_contextName, contextExtendedParams),
-        /**
-         * Creates a child feature within the current context.
-         *
-         * @param {string} childFeatureName - The name of the child feature.
-         * @param {ExtendedParams} [extendedParams={}] - Additional extended parameters for the child feature.
-         * @return {Function} The created error feature.
-         */
         feature: (childFeatureName: string, extendedParams: ExtendedParams = {}) => {
           const featureErrorContext = { ...contextExtendedParams, ...extendedParams };
           return _createErrorFeature(childFeatureName, _contextName, featureErrorContext);

--- a/index.ts
+++ b/index.ts
@@ -92,11 +92,28 @@ type CreateErrorFn<ErrorType extends string> = (
 ) => IConwayError;
 
 type ObjectWithEmit<ErrorType> = {
+  /**
+   * Creates and emits error of specified type.
+   *
+   * @param {ErrorTypes[number]["errorType"]} errorType - The type of the error to throw.
+   * @param {string} message - The message for the error.
+   * @param {Object} [options={}] - Optional parameters for the error.
+   * @param {Error} [options.originalError] - The original error that caused this error.
+   * @param {ExtendedParams} [options.extendedParams] - Additional extended parameters for the error.
+   * @return {void} This function does not return anything.
+   */
   emit: (
     errorType: ErrorType,
     message: string,
     options?: { originalError?: OriginalError; extendedParams?: ExtendedParams },
   ) => void;
+  /**
+   * Emits previously created error.
+   *
+   * @param {ErrorTypes[number]["errorType"]} error - already thrown previously error.
+   * @param {ExtendedParams} extendedParams - Additional extended parameters for the error.
+   * @return {void} This function does not return anything.
+   */
   emitCreated: (error: IConwayError, extendedParams?: ExtendedParams) => void;
 };
 

--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ function createContextedMessage(contextPath: string, featureName: string, messag
   return `${contextPath}/${featureName}: ${message}`;
 }
 
-function defaultEmitFn(err: IConwayError) {
+function defaultHandleEmit(err: IConwayError) {
   console.error(err);
 }
 
@@ -65,12 +65,12 @@ type ExtendedParams = Record<string, unknown>;
 type OriginalError = Error | Record<string, unknown> | unknown;
 
 interface CreateErrorOptions {
-  emitFn?: (err: IConwayError, extendedParams?: ExtendedParams) => void;
+  handleEmit?: (err: IConwayError, extendedParams?: ExtendedParams) => void;
   extendedParams?: ExtendedParams;
 }
 
 const defaultErrorOptions: CreateErrorOptions = {
-  emitFn: defaultEmitFn,
+  handleEmit: defaultHandleEmit,
   extendedParams: {},
 };
 
@@ -177,15 +177,15 @@ export function createError<ErrorTypes extends ErrorTypeConfig>(errorTypes?: Err
         const messagePostfix =
           originalError && errorMapItem?.createMessagePostfix ? errorMapItem.createMessagePostfix(originalError) : "";
 
-        const emitFn: EmitFn = (extendedParams = {}) => {
+        const emit: EmitFn = (extendedParams = {}) => {
           const _extendedParams = { ...featureContextExtendedParams, ...extendedParams };
-          _options.emitFn?.(error, _extendedParams);
+          _options.handleEmit?.(error, _extendedParams);
         };
 
         const error = new (errorMapItem?.errorClass ?? UnknownError)(
           contextName,
           createContextedMessage(contextName, featureName, message + messagePostfix),
-          emitFn,
+          emit,
           originalError,
         );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conway-errors",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conway-errors",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conway-errors",
   "source": "index.ts",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": false,
   "description": "Create errors with Conway's law",
   "exports": {


### PR DESCRIPTION
In new version we change API of error throwing. Instead of

```
featureError.throw(...
```

we make

```
throw featureError(...
```

so `featureError()` now returns instance of error. Also instance of returning error contains `emit` error method.
