### PR TITLE
Refactor error handling for emit function in example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ try {
   throw oauthError("FrontendLogicError", "User not found");
 }
 catch(error) {
-  (error as IConwayError).emit(error);
+  if (isConwayError(error)) {
+    error.emit(error);
+  }
 }
 
 // (6) You also can emit error without throwing

--- a/README_RU.md
+++ b/README_RU.md
@@ -34,7 +34,9 @@ try {
   throw oauthError("FrontendLogicError", "User not found");
 }
 catch(error) {
-  (error as IConwayError).emit(error);
+  if (isConwayError(error)) {
+    error.emit(error);
+  }
 }
 
 // (6) Пример эмиттинга ошибок без вызова throw 


### PR DESCRIPTION
This PR refines the error handling approach in the README's usage example by replacing direct type casting with a type guard (`isConwayError`). 

Previously, `(error as IConwayError).emit(error)` was used, but this change now checks for a `ConwayError` type using if `(isConwayError(error)) { error.emit(error); }`. 

This modification enhances type safety and improves readability for consumers of the library.