### PR TITLE
feat: branded types for context, subcontext and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,34 @@ const error = cardPaymentError("BackendLogicError", "Payment failed", { extended
 error.emit({ extendedParams: { logLevel: "fatal" } });
 ```
 
+### Helper Functions and Types
+
+#### AnyFeatureOfSubcontext
+
+Allows you to explicitly specify the type for any feature of the given subcontext.
+
+```ts
+import { createError } from "conway-errors";
+
+const createErrorContext = createError([
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" },
+] as const);
+
+const context = createErrorContext("Context");
+const subcontext = context.subcontext("Subcontext");
+
+const featureError1 = context.feature("Feature");
+const featureError2 = subcontext.feature("Feature");
+
+function customErrorThrower(featureError: AnyFeatureOfSubcontext<typeof subcontext>) {
+  // ...
+}
+
+customErrorThrower(featureError1); // error
+customErrorThrower(featureError2); // ok
+```
+
 ## Acknowledgment for Contributions
 
 <table>

--- a/README_RU.md
+++ b/README_RU.md
@@ -251,6 +251,34 @@ const error = cardPaymentError("BackendLogicError", "Payment failed", { extended
 error.emit({ extendedParams: { logLevel: "fatal" } })
 ```
 
+### Вспомогательные функции и типы
+
+#### AnyFeatureOfSubcontext
+
+Позволяет явно указать тип для любой feature указанного подконтекста.
+
+```ts
+import { createError } from "conway-errors";
+
+const createErrorContext = createError([
+  { errorType: "FrontendLogicError" },
+  { errorType: "BackendLogicError" },
+] as const);
+
+const context = createErrorContext("Context");
+const subcontext = context.subcontext("Subcontext");
+
+const featureError1 = context.feature("Feature");
+const featureError2 = subcontext.feature("Feature");
+
+function customErrorThrower(featureError: AnyFeatureOfSubcontext<typeof subcontext>) {
+  // ...
+}
+
+customErrorThrower(featureError1); // error
+customErrorThrower(featureError2); // ok
+```
+
 ## Благодарность за вклад
 
 <table>

--- a/index.test.ts
+++ b/index.test.ts
@@ -2,7 +2,7 @@ import { test } from "uvu";
 import { snoop } from "snoop";
 import * as assert from "uvu/assert";
 
-import { createError, isConwayError, type IConwayError } from "./index";
+import { createError, isConwayError } from "./index";
 
 test("without error types will throw always UnknownError", () => {
   const createErrorContext = createError();

--- a/index.ts
+++ b/index.ts
@@ -100,11 +100,6 @@ type ErrorMap = Record<
   }
 >;
 
-type FeatureFn<ErrorType extends string> = (
-  featureName: string,
-  featureContextExtendedParams?: ExtendedParams
-) => CreateErrorFn<ErrorType>;
-
 type ErrorFnOptions = {
   originalError?: OriginalError;
   extendedParams?: ExtendedParams;
@@ -116,7 +111,12 @@ type CreateErrorFn<ErrorType extends string> = (
   options?: ErrorFnOptions
 ) => IConwayError;
 
-type ErrorSubcontext<ErrorType extends string> = {
+type Brand<T, B> = T & { __brand: B };
+
+type ErrorSubcontext<Name extends string, ErrorType extends string> = Brand<Subcontext<Name, ErrorType>, Name>;
+type ErrorFeature<Name extends string, ErrorType extends string> = Brand<CreateErrorFn<ErrorType>, Name>;
+
+type Subcontext<Name extends string, ErrorType extends string> = {
   /**
    * Create a child context within the current context.
    *
@@ -124,7 +124,10 @@ type ErrorSubcontext<ErrorType extends string> = {
    * @param {ExtendedParams} extendedParams - Additional extended parameters for the child context.
    * @return {Function} Function to create an error context with the specified child context name and extended params.
    */
-  subcontext: (subcontextName: string, extendedParams?: ExtendedParams) => ErrorSubcontext<ErrorType>;
+  subcontext: <const ChildContextName extends string>(
+    subcontextName: ChildContextName,
+    extendedParams?: ExtendedParams
+  ) => ErrorSubcontext<`${Name}/${ChildContextName}`, ErrorType>;
   /**
    * Creates a child feature within the current context.
    *
@@ -132,7 +135,10 @@ type ErrorSubcontext<ErrorType extends string> = {
    * @param {ExtendedParams} [extendedParams={}] - Additional extended parameters for the child feature.
    * @return {Function} The created error feature.
    */
-  feature: FeatureFn<ErrorType>;
+  feature: <const FeatureName extends string>(
+    featureName: FeatureName,
+    featureContextExtendedParams?: ExtendedParams
+  ) => ErrorFeature<FeatureName, ErrorType>;
 };
 
 /**
@@ -146,7 +152,7 @@ export function createError<ErrorTypes extends ErrorTypeConfig>(errorTypes?: Err
   const _options = { ...defaultErrorOptions, ...options };
   const initialExtendedParams = options?.extendedParams ?? {};
 
-  return (contextName: string, extendedParams: ExtendedParams = {}) => {
+  return <const ContextName extends string>(contextName: ContextName, extendedParams: ExtendedParams = {}) => {
     const outerExtendedParams = { ...initialExtendedParams, ...extendedParams };
 
     const errorsMap: ErrorMap = Array.isArray(errorTypes)
@@ -162,30 +168,37 @@ export function createError<ErrorTypes extends ErrorTypeConfig>(errorTypes?: Err
     const UnknownError = createErrorClass("UnknownError", contextName);
 
     const _createSubcontext =
-      (contextName: string, subContextExtendedParams: ExtendedParams) =>
-      (childContextName: string, extendedParams: ExtendedParams = {}) => {
+      <const ContextName extends string>(contextName: ContextName, subContextExtendedParams: ExtendedParams) =>
+      <const ChildContextName extends string>(
+        childContextName: ChildContextName,
+        extendedParams: ExtendedParams = {}
+      ) => {
         const subErrorContext = { ...subContextExtendedParams, ...extendedParams };
         return _createErrorContext(`${contextName}/${childContextName}`, subErrorContext);
       };
 
-    function _createErrorContext(
-      _contextName: string,
+    function _createErrorContext<const ContextName extends string>(
+      _contextName: ContextName,
       contextExtendedParams: ExtendedParams = outerExtendedParams
-    ): ErrorSubcontext<ErrorTypes[number]["errorType"]> {
+    ): ErrorSubcontext<ContextName, ErrorTypes[number]["errorType"]> {
       return {
+        __brand: _contextName,
         subcontext: _createSubcontext(_contextName, contextExtendedParams),
-        feature: (childFeatureName: string, extendedParams: ExtendedParams = {}) => {
+        feature: <const FeatureName extends string>(
+          childFeatureName: FeatureName,
+          extendedParams: ExtendedParams = {}
+        ) => {
           const featureErrorContext = { ...contextExtendedParams, ...extendedParams };
           return _createErrorFeature(childFeatureName, _contextName, featureErrorContext);
         },
       };
     }
 
-    function _createErrorFeature(
-      featureName: string,
+    function _createErrorFeature<const FeatureName extends string>(
+      featureName: FeatureName,
       contextName: string,
       featureContextExtendedParams: ExtendedParams = {}
-    ) {
+    ): ErrorFeature<FeatureName, ErrorTypes[number]["errorType"]> {
       const createNewErrorObject: CreateErrorFn<ErrorTypes[number]["errorType"]> = (
         errorType,
         message: string,
@@ -215,7 +228,8 @@ export function createError<ErrorTypes extends ErrorTypeConfig>(errorTypes?: Err
         return error;
       };
 
-      return createNewErrorObject;
+      Object.assign(createNewErrorObject, { __brand: featureName });
+      return createNewErrorObject as ErrorFeature<FeatureName, ErrorTypes[number]["errorType"]>;
     }
 
     return _createErrorContext(contextName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conway-errors",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conway-errors",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "conway-errors",
   "source": "index.ts",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": false,
-  "description": "Create errors with Conway's law",
+  "description": "Simplify the creation, structuring and throwing of errors",
   "exports": {
     "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
@@ -31,8 +31,19 @@
     "/dist",
     "/package.json"
   ],
-  "keywords": [],
-  "author": "Kalagin Ivan",
+  "keywords": [
+    "errors",
+    "typescript",
+    "error-handling",
+    "custom-errors",
+    "structured-errors",
+    "error-utils",
+    "backend",
+    "exceptions",
+    "js-errors",
+    "application-error"
+  ],
+  "author": "ivklgn",
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "1.8.3",


### PR DESCRIPTION
now we can infer types from subcontext or features:

```ts
  const createErrorContext = createError([{ errorType: "ErrorType1" }, { errorType: "ErrorType2" }] as const);

  const errorContext1 = createErrorContext("Context1"); // infer: ErrorSubcontext<"Context1", "ErrorType1" | "ErrorType2">
  const errorContext2 = createErrorContext("Context2"); // infer: ErrorSubcontext<"Context2", "ErrorType1" | "ErrorType2">

  const featureError = errorContext.feature("Feature"); // infer: ErrorFeature<"Feature", "ErrorType1" | "ErrorType2">
```

as a result, we can more strictly specify the accepted contexts/features in our code

```ts
function foo(errorCtx: typeof errorContext1);
```